### PR TITLE
Fix API path handling in RestClient

### DIFF
--- a/lib/minds/rest_client.rb
+++ b/lib/minds/rest_client.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 module Minds
   module RestClient
     def get(path:)
@@ -26,14 +28,15 @@ module Minds
 
     def delete(path:, parameters: nil)
       conn.delete(uri(path: path)) do |req|
-        req.body = parameters.to_json
+        req.body = parameters.to_json unless parameters.nil?
       end&.body
     end
 
     private
 
     def uri(path:)
-      return path if @base_url.include?(@api_version)
+      base_path = URI(@base_url).path
+      return path if base_path.split("/").include?(@api_version)
 
       "/#{@api_version}/#{path}"
     end

--- a/spec/rest_client_spec.rb
+++ b/spec/rest_client_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.describe Minds::Client do
+  describe '#uri' do
+    it 'prefixes api version when base url lacks version path but contains substring in host' do
+      client = described_class.new(api_key: 'test', base_url: 'https://api.example.com')
+      expect(client.send(:uri, path: 'datasources')).to eq('/api/datasources')
+    end
+
+    it 'does not prefix api version when base url already includes version path' do
+      client = described_class.new(api_key: 'test', base_url: 'https://example.com/api')
+      expect(client.send(:uri, path: 'datasources')).to eq('datasources')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- fix API path prefix detection to handle base URLs with `api` in host but not in path
- avoid sending DELETE request body when no parameters
- add spec covering `#uri` behavior for various base URLs

## Testing
- `bundle exec rspec spec/rest_client_spec.rb` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68989e81665c8331b57d30836a051649