### PR TITLE
docs: fix typo in datasource comment

### DIFF
--- a/lib/minds/datasources.rb
+++ b/lib/minds/datasources.rb
@@ -37,7 +37,7 @@ module Minds
     # @option ds_config [String] :description Description of the database. Used by mind to understand what data can be retrieved from it.
     # @option ds_config [Hash] :connection_data (optional) Credentials to connect to the database
     # @option ds_config [Array<String>] :tables (optional) List of allowed tables
-    # @param update [Boolean] If true, to update datasourse if exists, default is false
+    # @param update [Boolean] If true, to update datasource if exists, default is false
     # @return [Datasource] The created datasource object
     # @raise [ObjectNotSupported] If datasource type is not supported
     #


### PR DESCRIPTION
## Summary
- fix typo in datasources comment

## Testing
- `bundle exec rake` *(fails: Could not find faraday-2.12.0, ruby-openai-7.3.1, rake-13.2.1, rspec-3.13.0, vcr-6.3.1, webmock-3.24.0, dotenv-3.1.4, rubocop-1.66.1, rubocop-rails-omakase-1.0.0, faraday-net_http-3.3.0, json-2.7.2, logger-1.6.1, event_stream_parser-1.0.0, faraday-multipart-1.0.4, rspec-core-3.13.1, rspec-expectations-3.13.3, rspec-mocks-3.13.2, base64-0.2.0, addressable-2.8.7, crack-1.0.0, hashdiff-1.1.1, language_server-protocol-3.17.0.3, parallel-1.26.3, parser-3.3.5.0, rainbow-3.1.1, regexp_parser-2.9.2, rubocop-ast-1.32.3, ruby-progressbar-1.13.0, unicode-display_width-2.6.0, rubocop-minitest-0.36.0, rubocop-performance-1.22.1, rubocop-rails-2.26.2, multipart-post-2.4.1, rspec-support-3.13.1, diff-lcs-1.5.1, public_suffix-6.0.1, bigdecimal-3.1.8, rexml-3.3.9, ast-2.4.2, racc-1.8.1, activesupport-7.1.4, rack-3.1.7, uri-0.13.1, concurrent-ruby-1.3.4, connection_pool-2.4.1, drb-2.2.1, i18n-1.14.6, minitest-5.25.1, mutex_m-0.2.0, tzinfo-2.0.6 in locally installed gems)*
- `bundle install` *(fails: 403 "Forbidden" while fetching gems)*

------
