### PR TITLE
Fix changelog class references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,22 @@
 ### Added
 - Initial release of the Minds Ruby SDK
 - Implemented `Minds::Client` for configuring and initializing the SDK
-- Added `Minds::Resources::Datasources` for managing data sources:
+- Added `Minds::Datasources` for managing data sources:
   - `create`: Create a new datasource
   - `all`: List all datasources
   - `find`: Get a datasource by name
   - `destroy`: Delete a datasource
-- Added `Minds::Resources::Minds` for managing minds:
+- Added `Minds::Minds` for managing minds:
   - `all`: List all minds
   - `find`: Get a mind by name
   - `create`: Create a new mind
   - `destroy`: Delete a mind
-- Implemented `Minds::Resources::Mind` class with methods:
+- Implemented `Minds::Mind` class with methods:
   - `update`: Update mind properties
   - `add_datasources`: Add a datasource to a mind
   - `destroy_datasources`: Remove a datasource from a mind
   - `completion`: Call mind completion (with streaming support)
-- Added support for various datasource types through `DatabaseConfig` class
+- Added support for various datasource types through `Minds::DatabaseConfig` class
 - Implemented error handling with custom error classes
 - Added YARD-style documentation for all public methods
 


### PR DESCRIPTION
## Summary
- Correct changelog to reference new Minds namespace (`Minds::Datasources`, `Minds::Minds`, `Minds::Mind`)
- Clarify datasource support uses `Minds::DatabaseConfig`

## Testing
- `bundle exec rspec` *(fails: bundler: command not found)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6898a2c34f78833191f63d721f4e969d